### PR TITLE
Bugfix/test failing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -265,9 +265,9 @@ class DuckduckgoSkill(CommonQuerySkill):
 
         utt = utt.strip()
         utt = self.extract_topic(utt)
-        utt = utt.replace("an ", "")   # ugh!
-        utt = utt.replace("a ", "")   # ugh!
-        utt = utt.replace("the ", "")   # ugh!
+        # TODO - improve method of cleaning input
+        for article in self.translated_articles:
+            utt = utt.replace(f"{article} ", "")
 
         if utt is not None:
             answer = self.query_ddg(utt)

--- a/dialog/en-us/ddg.specific.response.dialog
+++ b/dialog/en-us/ddg.specific.response.dialog
@@ -1,1 +1,0 @@
-Here is your answer from duck duck go

--- a/test/behave/ddg.feature
+++ b/test/behave/ddg.feature
@@ -3,7 +3,7 @@ Feature: DuckDuckGo Skill
   Scenario Outline: user asks a question about a person
     Given an english speaking user
      When the user says "<tell me about a person>"
-     Then "skill-ddg" should reply with dialog from "ddg.specific.response"
+     Then "skill-ddg" should reply with anything
      And mycroft reply should contain "<person>"
      Then dialog is stopped
 
@@ -21,7 +21,7 @@ Feature: DuckDuckGo Skill
   Scenario Outline: user asks a question about a place
     Given an english speaking user
      When the user says "<tell me about a place>"
-     Then "skill-ddg" should reply with dialog from "ddg.specific.response"
+     Then "skill-ddg" should reply with anything
      And mycroft reply should contain "<place>"
      Then dialog is stopped
 
@@ -34,7 +34,7 @@ Feature: DuckDuckGo Skill
   Scenario Outline: user asks a question about a thing
     Given an english speaking user
      When the user says "<tell me about a thing>"
-     Then "skill-ddg" should reply with dialog from "ddg.specific.response"
+     Then "skill-ddg" should reply with anything
      And mycroft reply should contain "<thing>"
      Then dialog is stopped
 
@@ -50,7 +50,7 @@ Feature: DuckDuckGo Skill
   Scenario Outline: user asks a question about an idea
     Given an english speaking user
      When the user says "<tell me about an idea>"
-     Then "skill-ddg" should reply with dialog from "ddg.specific.response"
+     Then "skill-ddg" should reply with anything
      And mycroft reply should contain "<idea>"
      Then dialog is stopped
 


### PR DESCRIPTION
#### Description
The VK tests were failing on mycroft-skills. It was due to the pre-answer filler dialog being removed from the response but not from the test.

This has been removed as the Skill answers very quickly by itself and feedback from users has been to not have this where possible. Given the whole system is now much faster, I think we can reduce the use of these a lot.

It also does a minor refactor to re-use the existing `articles.list` instead of having these english words hard-coded in the Skill code.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Run the VK tests.